### PR TITLE
Match on the authorization header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.9
+-----
+
+ - Match on bearer token
+
 1.1.8
 -----
 

--- a/cassettedeck/store.py
+++ b/cassettedeck/store.py
@@ -14,6 +14,12 @@ import vcr
 default_library = os.path.join(os.path.dirname(__file__), 'cassettes/')
 
 
+def authorization(r1, r2):
+    b1 = r1.headers.get('Authorization', '')
+    b2 = r2.headers.get('Authorization', '')
+    return b1 == b2
+
+
 class CassetteStore(object):
 
     def __init__(self, cassette_library_dir=None, ignore_hosts=(),
@@ -51,7 +57,7 @@ class CassetteStore(object):
         # Per-host cassettes unless self._cassette is specified
         name = self._cassette or URL(url).host
         path = os.path.join(self.library_dir, name)
-        cassette = vcr.cassette.Cassette(path, match_on=(uri, method, query, raw_body))
+        cassette = vcr.cassette.Cassette(path, match_on=(uri, method, query, raw_body, authorization))
         cassette._load()
         return cassette
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='cassettedeck',
-    version='1.1.8',
+    version='1.1.9',
     description='A library store and replay aiohttp requests',
     long_description='To simplify and speed up tests that make HTTP requests',
     author='Developer team at Onna Technologies',


### PR DESCRIPTION
BEWARE!! this can potentially break some previously recorded tests that didnt have into account this matcher.

Next step will be to allow configure the list of matchers in the cassettedeck constructor.