### PR TITLE
Remove content type injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 **/__pycache__/
 **/.mypy_cache
 **/cassettes
+/.idea/
+*.pyc
+*~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.13
+------
+
+- remove content-type injection in stored data
+
 1.1.12
 ------
 

--- a/cassettedeck/store.py
+++ b/cassettedeck/store.py
@@ -175,12 +175,6 @@ class CassetteStore(object):
         resp.status = resp_json['status']['code']
         resp.reason = resp_json['status']['message']
 
-        # Set default plain/text if no Content-Type
-        try:
-            resp_json['headers']['Content-Type']
-        except KeyError:
-            resp_json['headers']['Content-Type'] = 'plain/text'
-
         # Set headers and content
         resp.headers = CIMultiDict(resp_json['headers'])
         resp.content = StreamReader(Mock())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='cassettedeck',
-    version='1.1.12',
+    version='1.1.13',
     description='A library store and replay aiohttp requests',
     long_description='To simplify and speed up tests that make HTTP requests',
     author='Developer team at Onna Technologies',


### PR DESCRIPTION
The default content-type injection is breaking some of my tests because it was a case-sensitive check: `content-type` was present but `Content-Type` was then added with an incompatible value.