### PR TITLE
Pin aiohttp to >=3.4 and <3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /.idea/
 *.pyc
 *~
+.pytest_cache/
+*.egg-info/
+venv/
+stored_requests/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.0.2
+-----
+
+- Pin aiohttp to >=3.4 <3.6
+- Solve flake8 warnings
+
 2.0.1
 ------
 

--- a/cassettedeck/tests/test_works.py
+++ b/cassettedeck/tests/test_works.py
@@ -33,7 +33,7 @@ async def calling_localhost():
 async def calling_mocked_service(path):
     url = os.path.join('http://mocked.service.com', path)
     async with aiohttp.ClientSession() as s, s.get(url) as resp:
-        assert resp.status is 200
+        assert resp.status == 200
         assert resp.headers.get('Content-Type') == 'text/plain'
         result = await resp.text()
         return result

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='cassettedeck',
-    version='2.0.1',
+    version='2.0.2',
     description='A library store and replay aiohttp requests',
     long_description='To simplify and speed up tests that make HTTP requests',
     author='Developer team at Onna Technologies',
@@ -24,7 +24,7 @@ setup(
     package_data={'': ['*.txt', '*.rst']},
     packages=find_packages(),
     install_requires=[
-        'aiohttp~=3.4.4',
+        'aiohttp>=3.4,<3.6',
         'vcrpy==1.12.0',
         'PyYAML~=3.12.0'
     ]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,5 @@ pytest==3.5.1
 pytest-asyncio==0.8.0
 testfixtures==5.2.0
 flake8==3.4.1
-pytest-cov
+pytest-cov==2.6.0
 mypy


### PR DESCRIPTION
https://github.com/atlasense/product/issues/6330
Updating `aiohttp` dependency to avoid compatibility errors in spyders and clients